### PR TITLE
bug: fixed hood config and simulation

### DIFF
--- a/src/main/java/frc/robot/subsystems/HoodSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/HoodSubsystem.java
@@ -2,6 +2,8 @@ package frc.robot.subsystems;
 
 import static edu.wpi.first.units.Units.Amps;
 import static edu.wpi.first.units.Units.Degrees;
+import static edu.wpi.first.units.Units.Inches;
+import static edu.wpi.first.units.Units.Pounds;
 import static edu.wpi.first.units.Units.RPM;
 import static edu.wpi.first.units.Units.RotationsPerSecondPerSecond;
 import static edu.wpi.first.units.Units.Second;
@@ -59,6 +61,9 @@ public class HoodSubsystem extends SubsystemBase {
 
   private final ArmConfig hoodConfig =
       new ArmConfig(hoodSMC)
+          .withMass(Pounds.of(2))
+          .withStartingPosition(Degrees.of(25))
+          .withLength(Inches.of(9.3))
           .withTelemetry("HoodMech", TelemetryVerbosity.HIGH)
           .withSoftLimits(Degrees.of(5), Degrees.of(100))
           .withHardLimit(


### PR DESCRIPTION
**Context**: 

*GitHub Issue number* #36 
hood config bug was crashing simulation

**Description**: 
Added mass, length and starting position to hood config with values provided by mechanical.

**Tests**: 
- *Did build succeed?* Yes
- *Was it tested in simulation?* Simulation starts
- *Was it tested on the robot?* Not yet

**Issues**: 
n/a

**References**: 
- [WPILib](https://docs.wpilib.org/)
