### PR TITLE
Remove manip button B with negative flywheel and update test manip bindings

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -111,10 +111,6 @@ public class RobotContainer {
         .a()
         .whileTrue(flywheelSubsystem.setVelocity(() -> RPM.of(1900)))
         .whileFalse(flywheelSubsystem.setDutyCycle(0));
-    manipController
-        .b()
-        .whileTrue(flywheelSubsystem.setVelocity(() -> RPM.of(-1900)))
-        .whileFalse(flywheelSubsystem.setDutyCycle(0));
 
     // Intake
     manipController.leftBumper().whileTrue(new TestIntake(intakeSubsystem, 10));
@@ -220,17 +216,13 @@ public class RobotContainer {
     // Testing subsytem commands
 
     // Turret
-    manipController.povLeft().whileTrue(new TestTurret(turretSubsystem, 5));
-    manipController.povRight().whileTrue(new TestTurret(turretSubsystem, -5));
+    manipController.povLeft().whileTrue(new TestTurret(turretSubsystem, -5));
+    manipController.povRight().whileTrue(new TestTurret(turretSubsystem, 5));
 
     // Flywheel
     manipController
         .a()
-        .whileTrue(flywheelSubsystem.setVelocity(() -> RPM.of(1600)))
-        .whileFalse(flywheelSubsystem.setDutyCycle(0));
-    manipController
-        .b()
-        .whileTrue(flywheelSubsystem.setVelocity(() -> RPM.of(-1600)))
+        .whileTrue(flywheelSubsystem.setVelocity(() -> RPM.of(1900)))
         .whileFalse(flywheelSubsystem.setDutyCycle(0));
 
     // Intake
@@ -256,8 +248,8 @@ public class RobotContainer {
         new TestIntakeArm(intakeSubsystem, () -> manipController.getLeftY()));
 
     // Serializer
-    manipController.rightBumper().whileTrue(new TestSerializer(serializerSubsystem, 32));
-    manipController.rightTrigger().whileTrue(new TestSerializer(serializerSubsystem, -32));
+    manipController.rightBumper().whileTrue(new TestSerializer(serializerSubsystem, -32));
+    manipController.rightTrigger().whileTrue(new TestSerializer(serializerSubsystem, 32));
 
     // Drivetrain commands
     // Note that X is defined as forward according to WPILib convention,


### PR DESCRIPTION
**Context**: 

*GitHub Issue number* #57 
Related PR #66 

**Description**: 
- Remove manip button B with negative flywheel 
- update test manip bindings to match teleop manip bindings

**Tests**: 
- *Did build succeed?* Yes
- *Was it tested in simulation?*  
- *Was it tested on the robot?*


**Issues**: 
n/a


**References**: 
- [WPILib](https://docs.wpilib.org/)
