### PR TITLE
adjust intake arm binding

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -80,7 +80,11 @@ public class Robot extends TimedRobot {
 
   /** This function is called periodically during operator control. */
   @Override
-  public void teleopPeriodic() {}
+  public void teleopPeriodic() {
+    SmartDashboard.putNumber("Hood Angle", m_robotContainer.hoodSubsystem.getAngleDegrees());
+    SmartDashboard.putNumber("Turret Angle", m_robotContainer.turretSubsystem.getAngleDegrees());
+    SmartDashboard.putNumber("Flywheel Speed", m_robotContainer.flywheelSubsystem.getSpeedRPM());
+  }
 
   @Override
   public void teleopExit() {}

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -137,7 +137,7 @@ public class RobotContainer {
                 () -> AllianceFlipUtil.flip(FieldConstants.blueHub)));
     // IntakeArm
     intakeSubsystem.setDefaultCommand(
-        new TestIntakeArm(intakeSubsystem, () -> manipController.getLeftY() * 0.625));
+        new TestIntakeArm(intakeSubsystem, () -> -manipController.getLeftY() * 0.625));
 
     // Serializer
     manipController.rightBumper().whileTrue(new TestSerializer(serializerSubsystem, -32));
@@ -250,7 +250,7 @@ public class RobotContainer {
                 () -> AllianceFlipUtil.flip(FieldConstants.blueHub)));
     // IntakeArm
     intakeSubsystem.setDefaultCommand(
-        new TestIntakeArm(intakeSubsystem, () -> manipController.getLeftY()));
+        new TestIntakeArm(intakeSubsystem, () -> -manipController.getLeftY()));
 
     // Serializer
     manipController.rightBumper().whileTrue(new TestSerializer(serializerSubsystem, -32));


### PR DESCRIPTION
**Context**: 

*GitHub Issue number or motivation for the change*
Driver said that intake arm movement needed to be inverted. 

**Description**: 
Invert intake arm binding in teleop and test so that left joystick up moves intake arm up and left joystick down moves intake arm down. 

**Tests**: 
- *Did build succeed?* Yes
- *Was it tested in simulation?*  
- *Was it tested on the robot?* Yes


**Issues**: 
n/a


**References**: 
- [WPILib](https://docs.wpilib.org/)
