### PR TITLE
Adjusted wait time, shooting time and offset.

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -103,9 +103,9 @@ public class RobotContainer {
                 () -> drivetrain.getState().Speeds,
                 () -> AllianceFlipUtil.flip(FieldConstants.blueHub))
             .alongWith(
-                new WaitCommand(3)
+                new WaitCommand(4)
                     .andThen(new TestSerializer(serializerSubsystem, -32))
-                    .withTimeout(9)));
+                    .withTimeout(10)));
 
     autoChooser = AutoBuilder.buildAutoChooser("Comp-MovingBackFromCenter");
     SmartDashboard.putData("Auto Mode", autoChooser);

--- a/src/main/java/frc/robot/commands/ShootOnMoveCmd.java
+++ b/src/main/java/frc/robot/commands/ShootOnMoveCmd.java
@@ -30,7 +30,7 @@ public class ShootOnMoveCmd extends Command {
   private final Supplier<Pose2d> goalPoseSupplier;
   private final double latency = 0.4; //      <---------------NEED TO TUNE
   private final double offset =
-      1.3; //      <---------------NEED TO TUNE (in feet, added to distance to target for
+      1.7; //      <---------------NEED TO TUNE (in feet, added to distance to target for
   // interpolation tables to account for the fact that the robot is moving towards the target
   // while shooting)
   private final InterpolatingDoubleTreeMap shooterTable =


### PR DESCRIPTION
**Context**: 
To adjust the time for shooting, waiting, and offset changes for SOTM
**Description**: 
SOTM was overshooting or not shooting exact so we increased offset from 1.3 to 1.7 and adjusted the time for shooting to let flywheel ramp up. 

**Tests**: 
- *Did build succeed?* 
- *Was it tested in simulation?*  
- *Was it tested on the robot?*
It was tested on the robot

