### PR TITLE
increase backwards speed in BumpFuelShoot autos

### DIFF
--- a/src/main/deploy/pathplanner/paths/LeftBackward5m.path
+++ b/src/main/deploy/pathplanner/paths/LeftBackward5m.path
@@ -33,7 +33,7 @@
   "pointTowardsZones": [],
   "eventMarkers": [],
   "globalConstraints": {
-    "maxVelocity": 3.0,
+    "maxVelocity": 4.0,
     "maxAcceleration": 3.0,
     "maxAngularVelocity": 540.0,
     "maxAngularAcceleration": 720.0,
@@ -50,5 +50,5 @@
     "velocity": 0,
     "rotation": 179.768450347704
   },
-  "useDefaultConstraints": true
+  "useDefaultConstraints": false
 }

--- a/src/main/deploy/pathplanner/paths/RightBackward5m.path
+++ b/src/main/deploy/pathplanner/paths/RightBackward5m.path
@@ -33,7 +33,7 @@
   "pointTowardsZones": [],
   "eventMarkers": [],
   "globalConstraints": {
-    "maxVelocity": 3.0,
+    "maxVelocity": 4.0,
     "maxAcceleration": 3.0,
     "maxAngularVelocity": 540.0,
     "maxAngularAcceleration": 720.0,
@@ -50,5 +50,5 @@
     "velocity": 0,
     "rotation": 179.768450347704
   },
-  "useDefaultConstraints": true
+  "useDefaultConstraints": false
 }


### PR DESCRIPTION
**Context**:

*GitHub Issue number or motivation for the change*
When returning over the bump, the robot stops earlier than it should and cannot read April tags. Increase speed in return path in the hope the robot goes back further. 

**Description**:
increase backwards speed in Left/RightBumpFuelShoot autos

**Tests**:
- *Did build succeed?* Yes
- *Was it tested in simulation?* Yes
- *Was it tested on the robot?*


**Issues**:



**References**:
- [WPILib](https://docs.wpilib.org/)
