### PR TITLE
Drivetrain demo

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -351,7 +351,7 @@ public class RobotContainer {
     RobotModeTriggers.disabled()
         .whileTrue(drivetrain.applyRequest(() -> idle).ignoringDisable(true));
 
-    // driverController.a().whileTrue(drivetrain.applyRequest(() -> brake));
+    driverController.a().whileTrue(drivetrain.applyRequest(() -> brake));
     // driverController
     //     .b()
     //     .whileTrue(

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -370,8 +370,8 @@ public class RobotContainer {
     //     .whileTrue(
     //         drivetrain.applyRequest(() -> forwardStraight.withVelocityX(-0.5).withVelocityY(0)));
 
-    // // Reset the field-centric heading on left bumper press.
-    // driverController.leftBumper().onTrue(drivetrain.runOnce(drivetrain::seedFieldCentric));
+    // Reset the field-centric heading on left bumper press.
+    driverController.leftBumper().onTrue(drivetrain.runOnce(drivetrain::seedFieldCentric));
 
     // Run SysId routines when holding back/start and X/Y.
     // Note that each routine should be run exactly once in a single log.

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -375,22 +375,22 @@ public class RobotContainer {
 
     // Run SysId routines when holding back/start and X/Y.
     // Note that each routine should be run exactly once in a single log.
-    driverController
-        .back()
-        .and(driverController.y())
-        .whileTrue(drivetrain.sysIdDynamic(Direction.kForward));
-    driverController
-        .back()
-        .and(driverController.x())
-        .whileTrue(drivetrain.sysIdDynamic(Direction.kReverse));
-    driverController
-        .start()
-        .and(driverController.y())
-        .whileTrue(drivetrain.sysIdQuasistatic(Direction.kForward));
-    driverController
-        .start()
-        .and(driverController.x())
-        .whileTrue(drivetrain.sysIdQuasistatic(Direction.kReverse));
+    // driverController
+    //     .back()
+    //     .and(driverController.y())
+    //     .whileTrue(drivetrain.sysIdDynamic(Direction.kForward));
+    // driverController
+    //     .back()
+    //     .and(driverController.x())
+    //     .whileTrue(drivetrain.sysIdDynamic(Direction.kReverse));
+    // driverController
+    //     .start()
+    //     .and(driverController.y())
+    //     .whileTrue(drivetrain.sysIdQuasistatic(Direction.kForward));
+    // driverController
+    //     .start()
+    //     .and(driverController.x())
+    //     .whileTrue(drivetrain.sysIdQuasistatic(Direction.kReverse));
 
     drivetrain.registerTelemetry(logger::telemeterize);
   }

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -351,7 +351,7 @@ public class RobotContainer {
     RobotModeTriggers.disabled()
         .whileTrue(drivetrain.applyRequest(() -> idle).ignoringDisable(true));
 
-    driverController.a().whileTrue(drivetrain.applyRequest(() -> brake));
+    //driverController.a().whileTrue(drivetrain.applyRequest(() -> brake));
     // driverController
     //     .b()
     //     .whileTrue(


### PR DESCRIPTION
**Context**:
Removing drive train controls for demo

**Description**:
To prevent kids from pressing random buttons that could mess up the robot's drivetrain, we disabled everything except for the joysticks.

**Tests**:
It built successfully and was used during the open house demo.